### PR TITLE
feat: add the data spec for SBOM

### DIFF
--- a/api/spec/scanner-adapter-openapi-v1.2.yaml
+++ b/api/spec/scanner-adapter-openapi-v1.2.yaml
@@ -15,22 +15,19 @@ info:
     The [/metadata](#operation/GetMetadata) operation allows a Harbor admin to configure and register a scanner
     and discover its capabilities.
 
-    ## Supported consumed MIME types
+    ## Capabilities
 
-    - `application/vnd.oci.image.manifest.v1+json`
-    - `application/vnd.docker.distribution.manifest.v2+json`
+    | Capability Type | Supported consumed MIME types | Supported produced MIME types |
+    | --------------- | ----------------------------- | ----------------------------- |
+    |  vulnerability  | `application/vnd.oci.image.manifest.v1+json`<br>`application/vnd.docker.distribution.manifest.v2+json` | `application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0`<br>`application/vnd.security.vulnerability.report; version=1.1`<br>`application/vnd.scanner.adapter.vuln.report.raw`|
+    |     sbom        | `application/vnd.oci.image.manifest.v1+json`<br>`application/vnd.docker.distribution.manifest.v2+json` | `application/vnd.security.sbom.report+json; version=1.0` |
 
-    ## Supported produced MIME types
-    
-    - `application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0`
-    - `application/vnd.security.vulnerability.report; version=1.1`
-    - `application/vnd.scanner.adapter.vuln.report.raw`
   contact:
     email: cncf-harbor-maintainers@lists.cncf.io
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: "1.1"
+  version: "1.2"
 servers:
   - url: /api/v1
 security:
@@ -50,6 +47,9 @@ paths:
         200:
           description: Scanner's metadata and capabilities
           content:
+            "application/vnd.scanner.adapter.metadata+json; version=1.1":
+              schema:
+                $ref: '#/components/schemas/ScannerAdapterMetadata'
             "application/vnd.scanner.adapter.metadata+json; version=1.0":
               schema:
                 $ref: '#/components/schemas/ScannerAdapterMetadata'
@@ -73,6 +73,9 @@ paths:
           Contains data required to pull the given artifact and save it for scanning in the file system or any other
           location accessible to the scanner.
         content:
+          "application/vnd.scanner.adapter.scan.request+json; version=1.1":
+            schema:
+              $ref: '#/components/schemas/ScanRequest'
           "application/vnd.scanner.adapter.scan.request+json; version=1.0":
             schema:
               $ref: '#/components/schemas/ScanRequest'
@@ -97,6 +100,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         500:
           description: Internal server error
+          content:
+            "application/vnd.scanner.adapter.error+json; version=1.0":
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        501:
+          description: The scanner has no capability to handle the scan request
           content:
             "application/vnd.scanner.adapter.error+json; version=1.0":
               schema:
@@ -142,6 +151,9 @@ paths:
                   {
                     "vendor_specific": "vulnerabilities_report"
                   }
+            "application/vnd.security.sbom.report+json; version=1.0":
+              schema:
+                $ref: '#/components/schemas/HarborSbomReport'
         302:
           description: Status indicating the scan report is being generated and the request should be retried.
           headers:
@@ -153,6 +165,12 @@ paths:
           description: Cannot find the corresponding scan request identifier
         500:
           description: Internal server error
+          content:
+            "application/vnd.scanner.adapter.error+json; version=1.0":
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        501:
+          description: The scanner has no capability to handle the mime type
           content:
             "application/vnd.scanner.adapter.error+json; version=1.0":
               schema:
@@ -188,6 +206,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ScannerCapability'
+          example: |
+            [
+             {
+                "type": "vulnerability",
+                "consumes_mime_types": [
+                  "application/vnd.oci.image.manifest.v1+json",
+                  "application/vnd.docker.distribution.manifest.v2+json"
+                ],
+                "produces_mime_types": [
+                  "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+                ]
+              },
+              {
+                "type": "sbom",
+                "consumes_mime_types": [
+                  "application/vnd.oci.image.manifest.v1+json",
+                  "application/vnd.docker.distribution.manifest.v2+json"
+                ],
+                "produces_mime_types": [
+                  "application/vnd.security.sbom.report+json; version=1.0"
+                ]
+              }
+            ]
         properties:
           $ref: "#/components/schemas/ScannerProperties"
       description: |
@@ -206,6 +247,7 @@ components:
     ScannerCapability:
       description: |
         Capability consists of the set of recognized artifact MIME types and the set of scanner report MIME types.
+
         For example, a scanner capable of analyzing Docker images and producing a vulnerabilities report recognizable
         by Harbor web console might be represented with the following capability:
         - consumes MIME types:
@@ -213,11 +255,29 @@ components:
           - `application/vnd.docker.distribution.manifest.v2+json`
         - produces MIME types:
           - `application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0`
+
+        For example, a scanner capable of analyzing artifacts and producing a sbom report recognizable
+        by Harbor might be represented with the following capability:
+        - type: sbom
+        - consumes MIME types:
+          - `application/vnd.oci.image.manifest.v1+json`
+          - `application/vnd.docker.distribution.manifest.v2+json`
+        - produces MIME types:
+          - `application/vnd.security.sbom.report+json; version=1.0`
       required:
         - consumes_mime_types
         - produces_mime_types
       type: object
       properties:
+        type:
+          type: string
+          enum:
+          - vulnerability
+          - sbom
+          description: |
+            The type of the capability, for example, 'vulnerability' represents analyzing the artifact then producing the vulnerabilities report,
+            'sbom' represents generating the corresponding sbom for the artifact which be scanned. In order to the backward and forward compatible,
+            the field is optional, we think it's a original 'vulnerability' scan if no such field.
         consumes_mime_types:
           type: array
           items:
@@ -246,6 +306,36 @@ components:
           $ref: '#/components/schemas/Registry'
         artifact:
           $ref: '#/components/schemas/Artifact'
+        enabled_capabilities:
+          type: array
+          description: Enable which capabilities supported by scanner, for backward compatibility, without this field scanner can be considered to enable all capabilities by default.
+          items:
+            type: object
+            required:
+              - type
+            properties:
+              type:
+                type: string
+                enum:
+                - vulnerability
+                - sbom
+                description: The type of the scan capability.
+                example: sbom
+              produces_mime_types:
+                type: array
+                items:
+                  type: string
+                description: |
+                  The set of MIME types of reports generated by the scanner for the consumes_mime_types of the same capability record, it is a subset or fullset of the
+                  produces_mime_types of the capability returned by the metadata API, used for client to fine grained control of the expected report type. It's a optional
+                  field, only applied when client needs to customize it, otherwise the scanner can think it's a fullset as before behavior if without this field.
+                example:
+                  - "application/vnd.security.sbom.report+json; version=1.0"
+              parameters:
+                oneOf:
+                - $ref: '#/components/schemas/SbomParameters'
+                description: The additional parameters for the scan request, for the SBOM type, harbor will carry with `accept_media_type` to specify the expected format for SBOM content.
+                example: '{"accept_media_type": "application/spdx+json"}'
     ScanResponse:
       required:
         - id
@@ -258,6 +348,11 @@ components:
         identifier is not imposed but it should be unique enough to prevent collisons when polling for scan reports.
       type: string
       example: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    SbomParameters:
+      type: object
+      properties:
+        accept_media_type:
+          type: string
     Registry:
       type: object
       properties:
@@ -389,6 +484,31 @@ components:
         - Medium
         - High
         - Critical
+    HarborSbomReport:
+      type: object
+      properties:
+        generated_at:
+          type: string
+          format: 'date-time'
+          description: 'The time of the report generated.'
+        artifact:
+          $ref: '#/components/schemas/Artifact'
+        scanner:
+          $ref: '#/components/schemas/Scanner'
+        vendor_attributes:
+          type: object
+          additionalProperties: true
+          description: 'The additional attributes of the vendor.'
+        media_type:
+          type: string
+          enum:
+            - application/spdx+json
+            - application/vnd.cyclonedx+json
+          description: 'The format of the sbom data.'
+        sbom:
+          type: object
+          additionalProperties: true
+          description: 'The raw data of the sbom generated by the scanner.'
     ErrorResponse:
       type: object
       properties:

--- a/data/spec/SBOM.md
+++ b/data/spec/SBOM.md
@@ -1,3 +1,199 @@
-# Data spec for SBOM
+# Data Spec for SBOM
 
-TBD
+## MIME Type
+
+`application/vnd.security.sbom.report+json; version=1.0`
+
+## Report Data Model
+
+### Artifact
+
+| Field | Type | Description |
+| ------ | ----- | ----- |
+| `repository` | string | The name of the Docker Registry repository containing the artifact. |
+| `digest` | string | The artifact's digest, consisting of an algorithm and hex portion. |
+| `tag` | string | The artifact's tag. |
+| `mime_type` | string | The MIME type of the artifact. |
+
+### Scanner
+
+| Field | Type | Description |
+| ------ | ----- | ----- |
+| `name` | string | The name of the scanner. |
+| `vendor` | string | The name of the scanner's provider. |
+| `version` | string | The version of the scanner. |
+
+### Report
+
+| Field | Type | Description |
+| ------ | ----- | ----- |
+| `generated_at` | string | The time of the report generated. |
+| `artifact` | [artifact](#artifact) | The information of the scanned artifact. |
+| `scanner`  | [scanner](#scanner) | The information of the scanner. |
+| `vendor_attributes` | map[string]interface{} | The additional attributes of the vendor. |
+| `media_type` | string | The media type of the sbom data, currently only `application/spdx+json` and `application/vnd.cyclonedx+json` are supported.|
+| `sbom` | map[string]interface{} | The raw data of the sbom format by media_type. |
+
+### Example
+
+```json
+{
+  "generated_at": "2021-03-09T11:40:28.154072066Z",
+  "artifact": {
+     "repository": "library/docker",
+      "digest": "sha256:7215e8e09ea282e517aa350fc5380c1773c117b1867316fb59076d901e252d15",
+      "mime_type": "application/vnd.docker.distribution.manifest.v2+json"
+  },
+  "scanner": {
+      "name": "Trivy",
+      "vendor": "Aqua Security",
+      "version": "v0.16.0"
+  },
+  "vendor_attributes": {
+    "spec-version": "1.5",
+    "create-by": "trivy",
+    "create-time": "1695368355"
+  },
+  "media_type": "application/spdx+json",
+  "sbom": {
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "alpine:latest",
+    "documentNamespace": "<http://aquasecurity.github.io/trivy/container_image/alpine:latest-24fab3cb-05fa-479b-b3b7-f76151354cc3>",
+    "creationInfo":{
+      "licenseListVersion": "",
+      "creators": [
+        "Organization: aquasecurity",
+        "Tool: trivy-0.44.1"
+      ],
+      "created": "2023-09-22T07:41:04Z"
+    },
+    "packages": [
+        {
+          "name": "alpine",
+          "SPDXID": "SPDXRef-OperatingSystem-68bf9b9d283c287a",
+          "versionInfo": "3.18.3",
+          "downloadLocation": "NONE",
+          "copyrightText": "",
+          "primaryPackagePurpose": "OPERATING-SYSTEM"
+        },
+        ...
+    ]
+    ...
+    }
+  }
+}
+
+```
+
+### OpenAPI Definition
+
+```yaml
+components:
+  schemas:
+    ...
+    HarborSbomReport:
+      type: object
+      properties:
+        generated_at:
+          type: string
+          format: 'date-time'
+        artifact:
+          $ref: '#/components/schemas/Artifact'
+        scanner:
+          $ref: '#/components/schemas/Scanner'
+        vendor_attributes:
+          type: object
+          additionalProperties: true
+        media_type:
+          type: string
+          enum:
+            - application/spdx+json
+            - application/vnd.cyclonedx+json
+        sbom:
+          type: object
+          additionalProperties: true
+```
+
+## Statement
+
+### Generate SBOM
+
+The capability to generate the SBOM from the container image, the process is similar with the scan vulnerabilities, the scanner should pull the image from harbor and then generate SBOM, harbor will polling the scanner to get the SBOM until timeout or error occurred. The capabilities return from `/metadata` should includes the sbom capability.
+
+```json
+  "capabilities": [
+    {
+      "type": "vulnerability",
+      "consumes_mime_types": [
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json"
+      ],
+      "produces_mime_types": [
+        "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+      ]
+    },
+    {
+      "type": "sbom",
+      "consumes_mime_types": [
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json"
+      ],
+      "produces_mime_types": [
+        "application/vnd.security.sbom.report+json; version=1.0"
+      ]
+    }
+  ],
+```
+
+### Scan SBOM
+
+The capability to scan the image vulnerabilities from the SBOM of image, which have the better performance as the scanner only needs to pull the SBOM artifact instead of whole image. The basic process is exactly same with the image vulnerabilities scan because the SBOM has been bundled as an [OCI artifact](#harbor-sbom-artifact-layout). If the `artifactType` is `application/vnd.goharbor.harbor.sbom.v1` of the manifest, then scanner should treat is as SBOM artifact and pull the raw SBOM content from layers and scan vulnerabilities from it, the `artifact` field in the report should be the **subject** artifact.
+
+### Harbor SBOM Artifact Layout
+
+The support of [OCI Distribution spec v1.1's](https://github.com/goharbor/community/blob/main/proposals/new/distribution-1.1-adoption.md) referrer API in harbor enables the packaging of SBOM into OCI artifacts and their association with the respective subject artifact based on its attributes. Subsequently, by following the OCI distribution v2 image push process and API, you can push the SBOM artifact to Harbor, where it will be automatically processed as an accessory to the subject artifact. The layout is designed by following the [artifact guidelines](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/manifest.md#guidelines-for-artifact-usage).
+
+Here are some constraints:
+
+1. The `artifactType` MUST set to **application/vnd.goharbor.harbor.sbom.v1** because harbor leverages this to identify it as the SBOM, and set `config` to the [empty descriptor value](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/manifest.md#guidance-for-an-empty-descriptor).
+2. The SBOM file should be packed as the artifact layer, should not be compressed, the `mediaType` should set the format of the SBOM file, currently only **application/spdx+json** and **application/vnd.cyclonedx+json** are supported. (These mediaType are registered on the [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml))
+3. The vendor can add the customize attributes to the `annotations`.
+4. The `subject` should set the info of the subject artifact.
+5. The `layers` should only contains one layer which storing the SBOM file, you should separate to multiple SBOM artifact if you have multiple SBOM files with different formats.
+
+Example
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.goharbor.harbor.sbom.v1",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "size": 2,
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "data": "e30="
+  },
+  "layers": [
+    {
+      "mediaType": "application/spdx+json",
+      "size": 180911,
+      "digest": "sha256:5969ee831c94c0d918ceb6efc2463c032100afd03d721e920dafefd34913f2f4"
+    }
+  ],
+  "annotations": {
+    "created-by": "trivy",
+    "org.opencontainers.artifact.created": "2023-09-01T15:17:14+08:00",
+    "org.opencontainers.artifact.description": "SPDX JSON SBOM"
+  },
+  "subject": {
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "size": 3040,
+    "digest": "sha256:0f27d0c6b893b0298fca3c6c7253db047b7c21a9f6815da53ab4208000b839d8"
+  }
+}
+```
+
+## Open Questions


### PR DESCRIPTION
Adds the data spec for SBOM, and define the related data schemas, release the new API version v1.2.