### PR TITLE
Fix structure issues in 1.2.0 spec

### DIFF
--- a/api/spec/scanner-adapter-openapi-v1.2.yaml
+++ b/api/spec/scanner-adapter-openapi-v1.2.yaml
@@ -140,9 +140,9 @@ paths:
           required: false
           schema: 
             type: string
-          enum:
-            - application/spdx+json
-            - application/vnd.cyclonedx+json
+            enum:
+              - application/spdx+json
+              - application/vnd.cyclonedx+json
       responses:
         200:
           description: Scan report
@@ -320,7 +320,7 @@ components:
             - "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
         additional_attributes:
           type: object
-          descriptions: The additional attributes for scanner capabilities. If the type is sbom, then it returns supported media types of the SBOM format.
+          description: The additional attributes for scanner capabilities. If the type is sbom, then it returns supported media types of the SBOM format.
           example: |
             {
               "sbom_media_types": [


### PR DESCRIPTION
Currently, the v1.2 spec is not a valid OpenAPI file and cannot be used with tooling like openapi-generator-cli. This PR fixes 2 typos and makes it a valid spec.

Fix:
- components.schemas.ScannerCapability.descriptions should be 'description'
- paths.'/scan/{scan_request_id}/report'(get).parameters.[sbom_media_type].enum is improperly indented, should be part of 'schema'