### PR TITLE
feat(example): Add Go 'example-scanner' example for developers

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,31 @@
+# ---- Build Stage ----
+# Use an official Go image as the builder.
+FROM golang:1.20-alpine AS builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy go.mod and go.sum files to download dependencies
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+# Copy the source code into the container
+COPY *.go ./
+
+# Build the Go app. CGO_ENABLED=0 is important for a static binary.
+# -o /go-hello-scanner creates the output file at the root.
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /go-hello-scanner
+
+# ---- Final Stage ----
+# Use a minimal, non-root alpine image for the final container.
+FROM gcr.io/distroless/static-debian11
+
+# Copy the compiled binary from the builder stage.
+COPY --from=builder /go-hello-scanner /
+
+# Expose port 8080 to the outside world.
+EXPOSE 8080
+
+# Command to run when the container starts.
+CMD ["/go-hello-scanner"]

--- a/examples/example-scanner.go
+++ b/examples/example-scanner.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Scanner struct { // This struct is used to store the Metadata of the Scanner object
+	Name    string `json:"name"`
+	Vendor  string `json:"vendor"`
+	Version string `json:"version"`
+}
+
+type Capability struct { //This struct is used to store the type and different MIME types formats
+	Type              string   `json:"type"`
+	ConsumerMIMETypes []string `json:"consumer_mime_types"`
+	ProductMIMETypes  []string `json:"product_mime_types"`
+}
+
+type MetadataResponse struct {
+	Scanner      Scanner           `json:"scanner"`
+	Capabilities []Capability      `json:"capability"`
+	Properties   map[string]string `json:"propeties"`
+}
+
+type ScanRequest struct {
+}
+
+type ScanResponse struct {
+	ID string `json:"id"`
+}
+
+var scanTimeStamps = make(map[string]time.Time)
+
+func scanHandler(w http.ResponseWriter, r *http.Request) { // After providing the metaa data, this function immeadiately
+	if r.Method != http.MethodPost { // doesn't start the scanning, but takes it sends back the UUID and accepted status
+		http.Error(w, "Only POST method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	scanID := uuid.New().String() // Generates a unique UUID for each scan request
+	scanTimeStamps[scanID] = time.Now()
+	log.Printf("Accepted New Scan request with ID: %s", scanID)
+
+	response := ScanResponse{ID: scanID} // Sends back the status of accepted
+	w.Header().Set("Content-type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(response)
+
+}
+
+func reportHandler(w http.ResponseWriter, r *http.Request) { // This function checks if client asks for report within 10 seconds if it does, then it gracefully asks to retry afetr 10 seconds
+	scanID := strings.TrimPrefix(r.URL.Path, "/api/v1/scan/")
+	scanID = strings.TrimSuffix(scanID, "/report")
+
+	startTime, ok := scanTimeStamps[scanID] // Checks if the scanner ID exists
+	if !ok {
+		http.Error(w, "Scan Request Not Found", http.StatusNotFound)
+		return
+	}
+
+	if time.Since(startTime) < 10*time.Second { // Checks if it's atleast been 10 seconds
+		log.Printf("Scan Report for %s is not yet ready. Try after 10 seconds!", scanID)
+		w.Header().Set("Retry-After", "10")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	log.Printf("Scan Report ready for %s. Checking Accepted Header", scanID)
+
+	acceptHeader := r.Header.Get("Accept") // This block checks for the compatible header type
+	report := getHardcodedV11Report()
+
+	if strings.Contains(acceptHeader, "application/vnd.security.vulnerability.report; version=1.1") ||
+		strings.Contains(acceptHeader, "*/*") || strings.Contains(acceptHeader, "text/html") {
+
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(report)
+
+	} else {
+		log.Printf("Client request unsupported header request")
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(http.StatusNotAcceptable)
+		w.Write([]byte(`{"error" : Unacceptable Header type. Try using curl or postman}`))
+	}
+
+}
+
+func getHardcodedV11Report() map[string]interface{} {
+	return map[string]interface{}{
+		"generated at": time.Now().Format(time.RFC1123),
+		"artifact": map[string]string{
+			"repository": "library/photon",
+			"digest":     "sha256:..",
+		},
+		"scanner": map[string]string{
+			"name":    "Go Example scanner",
+			"vendor":  "Harbor Contributor",
+			"version": "v1.0.0",
+		},
+		"vulnerabilities": []map[string]string{
+			{
+				"id":          "CVE-2034-0464",
+				"package":     "openssl",
+				"version":     "3.0.8-r1",
+				"severity":    "High",
+				"description": "A vunerability in openssl",
+			},
+		},
+	}
+}
+
+func metadataHandler(w http.ResponseWriter, r *http.Request) { // This function is used to provide the Metadata, Capabilities and Properties to the client
+	metadata := MetadataResponse{
+		Scanner: Scanner{
+			Name:    "Hello Handler",
+			Vendor:  "Harbor Contributor",
+			Version: "1.0.0",
+		},
+		Capabilities: []Capability{
+			{
+				Type:              "Vulnerability",
+				ConsumerMIMETypes: []string{"application/vnd.oci.image.manifest.v1+json", "application/vnd.docker.distribution.manifest.v2+json"},
+				ProductMIMETypes:  []string{"application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0", "application/vnd.security.vulnerability.report; version=1.1"},
+			},
+		},
+		Properties: map[string]string{
+			"harbor.scanner-adapter/scanner-type": "os-package-vulnerability",
+			"example.property/is-a-poc":           "true",
+		},
+	}
+
+	w.Header().Set("Content-type", "application/vnd.scanner.adapter.metadata+json; version=1.1")
+
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		log.Printf("Error while encoding the data into json")
+		http.Error(w, "Error while generating metadata", http.StatusInternalServerError)
+	}
+}
+
+func main() {
+	http.HandleFunc("/api/v1/metadata", metadataHandler)
+	http.HandleFunc("/api/v1/scan", scanHandler)
+	http.HandleFunc("/api/v1/scan/", reportHandler)
+	log.Println("Example Scanner listening at port 8080 :")
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("Failed to start the server : %s", err)
+	}
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,5 @@
+module pluggable-scanner-spec
+
+go 1.21
+
+require github.com/google/uuid v1.6.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This "example-scanner" example is a fully functional, containerized Go application that correctly mimcs the entire API flow. Its purpose is to serve as a clear, working example for any developer looking to build a new scanner adapter.

This demonstrates:
- A correct implementation of the `GET /metadata` endpoint.
- A fully asynchronous `POST /scan` endpoint that returns a `202 Accepted` status.
- A `GET /report` endpoint that simulates processing delays by using the `Retry-After` header and `302 Found` status.
- A working example of server-side content negotiation via the `Accept` header to serve different report formats.


<img width="748" height="467" alt="Screenshot 2025-08-02 123942" src="https://github.com/user-attachments/assets/59d60f44-a5a4-45d9-8966-4003d683e914" />
